### PR TITLE
ci(docker): Triggering Trivy workflow after published builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,8 +87,8 @@ jobs:
           tags: ttl.sh/${{ env.IMAGE_NAME }}:${{ github.sha }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7,linux/arm/v6 # match caddy
-          cache-from: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:1h
-          cache-to: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:1h
+          cache-from: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:3h
+          cache-to: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:3h
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.9.2
@@ -115,7 +115,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-          cache-from: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:1h
+          cache-from: type=registry,ref=ttl.sh/${{ env.IMAGE_NAME }}-cache:3h
 
       - name: Sign Docker images
         if: github.event_name == 'push'
@@ -134,3 +134,7 @@ jobs:
           git push -f -u origin "v$MAJOR"
           git push -f -u origin "v$MAJOR.$MINOR"
           git push -f -u origin "v$CADDY_VERSION"
+
+      - name: Re-scan latest Docker image after publishing
+        if: github.event_name == 'push'
+        uses: ./.github/workflows/trivy.yml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: 0 0 * * * # daily at midnight
+  workflow_call:
 
 jobs:
   trivy-repo:
@@ -36,7 +37,7 @@ jobs:
     name: Scan latest Docker image
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_call'
     steps:
       - name: Checkout GitHub repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Updates Security tab immediately instead of needing to wait for the next scheduled scan.