### PR TITLE
feat: Pinning to image digests

### DIFF
--- a/.github/workflows/cache-sync.yml
+++ b/.github/workflows/cache-sync.yml
@@ -28,8 +28,8 @@ jobs:
         shell: bash
         run: |
           IMAGE_NAME=$(echo "${GITHUB_REPOSITORY/docker-/}" | tr '[:upper:]' '[:lower:]')
-          BASE_BRANCH=$(echo ${GITHUB_BASE_REF//[^a-zA-Z0-9]/-} | tr '[:upper:]' '[:lower:]')
-          HEAD_BRANCH=$(echo ${GITHUB_HEAD_REF//[^a-zA-Z0-9]/-} | tr '[:upper:]' '[:lower:]')
+          BASE_BRANCH=$(echo "${GITHUB_BASE_REF//[^a-zA-Z0-9]/-}" | tr '[:upper:]' '[:lower:]')
+          HEAD_BRANCH=$(echo "${GITHUB_HEAD_REF//[^a-zA-Z0-9]/-}" | tr '[:upper:]' '[:lower:]')
           echo "ttl.sh/$IMAGE_NAME:$HEAD_BRANCH --> ttl.sh/$IMAGE_NAME:$BASE_BRANCH"
           regctl image copy \
             --verbosity info \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -154,12 +154,12 @@ jobs:
           body-includes: View Workflow Run
           direction: first
 
-      - name: Add/Update PR success comment
-        if: github.event_name == 'pull_request' && success() == true
+      - name: Add/Update PR comment
+        if: github.event_name == 'pull_request' && cancelled() == false
         uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         with:
           message-id: ${{ steps.find.outputs.comment-id }}
-          message: |
+          message-success: |
             ## ✅ PR built successfully!
 
             #### **[⏩ View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
@@ -169,13 +169,7 @@ jobs:
             ```
             ttl.sh/${{ needs.metadata.outputs.image-name }}@${{ steps.build.outputs.digest }}
             ```
-
-      - name: Add/Update PR failure comment
-        if: github.event_name == 'pull_request' && failure() == true
-        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
-        with:
-          message-id: ${{ steps.find.outputs.comment-id }}
-          message: |
+          message-failure: |
             ## 💥 PR build failure!
 
             #### **[⏩ View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         id: build-metadata
         shell: bash
         run: |
-          IMAGE_TITLE=$(echo "$GITHUB_REPOSITORY" | sed 's/.*docker-//g')
+          IMAGE_TITLE=${GITHUB_REPOSITORY/*docker-/}
           IMAGE_NAME=$(echo "${GITHUB_REPOSITORY/docker-/}" | tr '[:upper:]' '[:lower:]')
           CADDY_VERSION=$(grep -m 1 -Eo 'caddy:[0-9]+\.[0-9]+\.[0-9]+' Dockerfile \
             | sed -E 's/.+:([0-9]+\.[0-9]+\.[0-9]+)(.+)?$/\1/g')
@@ -262,9 +262,9 @@ jobs:
         env:
           CADDY_VERSION: ${{ needs.metadata.outputs.caddy-version }}
         run: |
-          MAJOR=$(echo $CADDY_VERSION | cut -d . -f 1)
-          MINOR=$(echo $CADDY_VERSION | cut -d . -f 2)
-          PATCH=$(echo $CADDY_VERSION | cut -d . -f 3)
+          MAJOR=$(echo "$CADDY_VERSION" | cut -d . -f 1)
+          MINOR=$(echo "$CADDY_VERSION" | cut -d . -f 2)
+          PATCH=$(echo "$CADDY_VERSION" | cut -d . -f 3)
           git tag -f "v$MAJOR"
           git tag -f "v$MAJOR.$MINOR"
           git tag -f "v$MAJOR.$MINOR.$PATCH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
-FROM caddy:2.8.4-builder AS builder
+FROM caddy:2.8.4-builder@sha256:b1ee6157da9ce89796a6ce266713d701b383a17db2fa9cdb6dac04ef157544c8 AS builder
 RUN xcaddy build \
   --with github.com/caddy-dns/cloudflare
 
-FROM caddy:2.8.4
+FROM caddy:2.8.4@sha256:1841e7c656154710f2fec273e12d4e517eeea5bd7a6c75e01dd26b88aaba9646
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
Including the `sha256:...` digest for both the builder and normal caddy images. Dependabot supports updating these along with the tag, if the tag is still included!

Also some linting fixes.